### PR TITLE
Remove arguments parameter to GET request

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -120,17 +120,12 @@ base = 'https://trello.com/1/'
 # Build out the URL based on the documentation
 boards_url = base + 'members/me/boards'
 
-# Let's store our API key and token as parameters
-params_key_and_token = {'key':key,'token':token}
-
-# Since we only want the name of the board, let's supply the 'fields' argument as well. We're also going to 
-# ask for lists, to be used later.
-arguments = {'fields': 'name', 'lists': 'open'}
+# Let's store our API key and token as parameters, and specify we want all open lists,  to be used later.
+params = {'key':key, 'token':token, 'lists': 'open'}
 
 # The requests library has separate methods for get, put, post, and delete. We need a GET here.
-# We need to provide the URL we want to access, the key and token (params_key_and_token) as params, as well as
-# any arguments (arguments) as data.
-response = requests.get(boards_url, params=params_key_and_token, data=arguments)
+# We need to provide the URL we want to access and the key and token (params_key_and_token) as params.
+response = requests.get(boards_url, params=params)
 
 # We should pause here and point out that the requests library is making everying incredibly
 # easy for us. We're able to work in native python dictionaries and requests is automatically


### PR DESCRIPTION
I'm not sure why this is happening, but `arguments` doesn't seem to have any effect in the API call. The same data is returned with or without it.

Additionally, the file currently does not run as is, there's an error:

```
Traceback (most recent call last):
  File "demo.py", line 181, in <module>
    id_list = board['lists'][0]['id']
KeyError: 'lists'
```

I believe this is because lists default to `none`, ([API docs](https://developers.trello.com/v1.0/reference#membersidboards)) and since the data variable does not seem to have any effect, no lists are returned. Why data has no effect, I'm not sure. Lumping the lists into the params variable fixes this problem, and the file runs without error.